### PR TITLE
Dash components recipe: DashBootstrapComponents-v0.12.2

### DIFF
--- a/DashBootstrapComponents/Recipe.yml
+++ b/DashBootstrapComponents/Recipe.yml
@@ -1,0 +1,12 @@
+name: "DashBootstrapComponents"
+version: "0.12.2"
+py_package: "dash_bootstrap_components"
+type: github
+prefix: "dbc"
+build_script: |
+  npm install
+  npm run build
+  
+source:
+  url: "https://github.com/facultyai/dash-bootstrap-components.git"
+  hash: "5ddde022e6224d42c42ef68727a74f0cad2cce30"


### PR DESCRIPTION
This pull request contains a new build recipe I built using the DashComponentsBuilder.jl:

* Package name: DashBootstrapComponents
* Base Python package name: dash_bootstrap_components
* Version: v0.12.2

