### PR TITLE
Dash components recipe: DashBootstrapComponents-v0.12.2

### DIFF
--- a/DashBootstrapComponents/Recipe.yml
+++ b/DashBootstrapComponents/Recipe.yml
@@ -1,0 +1,5 @@
+name: "DashBootstrapComponents"
+version: "0.12.2"
+py_package: "dash_bootstrap_components"
+type: pypi
+prefix: "dbc"


### PR DESCRIPTION
This pull request contains a new build recipe I built using the DashComponentsBuilder.jl:

* Package name: DashBootstrapComponents
* Base Python package name: dash_bootstrap_components
* Version: v0.12.2

